### PR TITLE
fix(GitHub-Actions): Run Test workflow on caller

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,12 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
-        with:
-          repository: ScribeMD/pre-commit-action
       - name: Install and run pre-commit hooks.
+        if: ${{ github.repository == 'ScribeMD/pre-commit-action' }}
         uses: ./
+      - name: Install and run pre-commit hooks.
+        if: ${{ github.repository != 'ScribeMD/pre-commit-action' }}
+        uses: ScribeMD/pre-commit-action@main
       - name: Send Slack notification with job status.
         if: always()
         uses: ScribeMD/slack-templates@0.2.2


### PR DESCRIPTION
Check out the caller's repository rather than pre-commit-action in the Test workflow so that pre-commit-action is run on it and not itself.