### PR TITLE
docs(GitHub-Actions): Differentiate step names

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
-      - name: Install and run pre-commit hooks.
+      - name: Install and run pre-commit hooks (self-test).
         if: ${{ github.repository == 'ScribeMD/pre-commit-action' }}
         uses: ./
-      - name: Install and run pre-commit hooks.
+      - name: Install and run pre-commit hooks (called workflow).
         if: ${{ github.repository != 'ScribeMD/pre-commit-action' }}
         uses: ScribeMD/pre-commit-action@main
       - name: Send Slack notification with job status.


### PR DESCRIPTION
Make the workflow logs easier to read by clarifying the rationale for having two separate "Install and run pre-commit hooks" steps. One handles the case where the workflow is called from within this repository, and the other handles the case where it's called externally.