### PR TITLE
docs(action): Rename action so it can be released

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: ScribeMD Pre-commit
+name: Pre-commit Optimized for ScribeMD/pre-commit-hooks
 author: Kurt von Laven
 description: >
   Install pre-commit via asdf and Poetry; then run pre-commit hooks with extra


### PR DESCRIPTION
GitHub Actions erroneously complains the name "ScribeMD Pre-commit" is in use, which is blocking the release of this action to the GitHub Marketplace. Rename the action "Pre-commit Optimized for ScribeMD/pre-commit-hooks" to work around the error.