### PR TITLE
docs(contributing): Remove `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing Guide
-
-See [CONTRIBUTING.md of ScribeMD/slack-templates](https://github.com/ScribeMD/slack-templates/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ GitHub Action Optimized for Running
 - [pre-commit-action](#pre-commit-action)
   - [Usage](#usage)
   - [Supported Runners](#supported-runners)
-  - [Contributing](#contributing)
   - [Changelog](#changelog)
 
 <!--TOC-->
@@ -48,10 +47,6 @@ protect the default branch.
 
 Please refer to
 [README.md of ScribeMD/rootless-docker](https://github.com/ScribeMD/rootless-docker#supported-runners).
-
-## Contributing
-
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Changelog
 


### PR DESCRIPTION
It has been moved from slack-templates to the special .github repository. All repositories without their own contributing guide default to that shared guide.