### PR TITLE
fix(GitHub-Actions): Upgrade to latest versions

### DIFF
--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-assignee:
     name: Notify Assignee
-    uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@0.3.0
+    uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@0.3.2
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ASSIGN_CHANNEL_ID: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-reviewers:
     name: Notify Reviewers
-    uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@0.3.0
+    uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@0.3.2
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
           !inputs.no_bump
           && github.event_name == 'push' && github.ref == 'refs/heads/main'
           && !startsWith(github.event.head_commit.message, 'bump:')
-        uses: commitizen-tools/commitizen-action@0.13.0
+        uses: commitizen-tools/commitizen-action@0.13.1
         with:
           git_name: commitizen-github-action[bot]
           git_email: commitizen-github-action[bot]@users.noreply.github.com
@@ -55,7 +55,7 @@ jobs:
           commitizen_version: 2.24.0 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
       - name: Send Slack notification with job status.
         if: always()
-        uses: ScribeMD/slack-templates@0.3.0
+        uses: ScribeMD/slack-templates@0.3.2
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}


### PR DESCRIPTION
Pull in fix for commitizen-action. The default branch was previously master, but we have a main rather than a master branch. The default branch was corrected upstream to be the current branch instead.

commitizen-tools/commitizen-action 0.13.0 --> 0.13.1
ScribeMD/slack-templates 0.3.0 --> 0.3.2