### PR TITLE
style(action): Prefer `$ASDF_DIR` to hard-coded path

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: asdf-vm/actions/install@v1.1.0
     - name: Add Poetry and its dependencies to PATH.
       run: |
-        for version in ~/.asdf/installs/poetry/*; do
+        for version in "$ASDF_DIR/installs/poetry/"*; do
           echo "$version/bin" >>"$GITHUB_PATH"
         done
         echo "${{ github.workspace }}/.venv/bin" >>"$GITHUB_PATH"


### PR DESCRIPTION
The asdf setup action currently installs asdf to `~/.asdf`, but since it sets `$ASDF_DIR` to the directory it installs asdf to, use that instead in case the path changes upstream.