### PR TITLE
docs(bump): Must check out full repository history

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ If `"true"`, run
 push to `main` to commit a version bump and tag a release if there are any
 release-worthy changes. Uses your
 [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication),
-which must have write access to your repository.
+which must have write access to your repository. Commitizen relies on tags in
+order to preform an incremental release, so you must pass
+[`fetch-depth: 0`](https://github.com/marketplace/actions/checkout#Fetch-all-history-for-all-tags-and-branches)
+to [`checkout`](https://github.com/marketplace/actions/checkout) unless `bump`
+is `"false"`.
 
 ## Supported Runners
 

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,10 @@ inputs:
   bump:
     description: >
       If "true," run the Commitizen action on push to main to commit a version
-      bump and tag a release if there are any release-worthy changes.
+      bump and tag a release if there are any release-worthy changes. Commitizen
+      relies on tags in order to preform an incremental release, so you must pass
+      fetch-depth: 0 to the official GitHub checkout action unless bump is
+      "false."
     required: false
     default: "true"
 runs:


### PR DESCRIPTION
When `bump` is `true`, the Commitizen action is run, which relies on Git tags. The official GitHub checkout action does a sparse checkout by default, which does not include tags, causing version bumps to fail.