### PR TITLE
docs(CSpell): Correct "Preform" to "Perform"

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,2 @@
+!preform
 Laven

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ push to `main` to commit a version bump and tag a release if there are any
 release-worthy changes. Uses your
 [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication),
 which must have write access to your repository. Commitizen relies on tags in
-order to preform an incremental release, so you must pass
+order to perform an incremental release, so you must pass
 [`fetch-depth: 0`](https://github.com/marketplace/actions/checkout#Fetch-all-history-for-all-tags-and-branches)
 to [`checkout`](https://github.com/marketplace/actions/checkout) unless `bump`
 is `"false"`.

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     description: >
       If "true," run the Commitizen action on push to main to commit a version
       bump and tag a release if there are any release-worthy changes. Commitizen
-      relies on tags in order to preform an incremental release, so you must pass
+      relies on tags in order to perform an incremental release, so you must pass
       fetch-depth: 0 to the official GitHub checkout action unless bump is
       "false."
     required: false

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -2,6 +2,7 @@ version: "0.2"
 language: en-US
 useGitignore: true
 ignorePaths:
+  - .dictionary.txt
   - .vscode
 dictionaryDefinitions:
   - name: custom


### PR DESCRIPTION
The former means forming something beforehand, while the latter means doing something. Add "preform" to the ban list since it will almost always be a typo.