### PR TITLE
fix(asdf): Upgrade from v0.10.1 to v0.10.2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,14 +26,14 @@ runs:
     - name: Install asdf.
       uses: asdf-vm/actions/setup@v1.1.0
       with:
-        asdf_branch: v0.10.1
+        asdf_branch: v0.10.2
     - name: Cache asdf and asdf-managed tools.
       uses: actions/cache@v3.0.3
       id: asdf-cache
       with:
         path: ${{ env.ASDF_DIR }}
         key: >
-          asdf-v0.10.1-${{ steps.os.outputs.image }}-${{
+          asdf-v0.10.2-${{ steps.os.outputs.image }}-${{
             hashFiles('**/.tool-versions')
           }}
     - name: Install asdf-managed tools based on .tool-versions.


### PR DESCRIPTION
This invalidates the asdf cache. Developers can run `asdf update` locally.