### PR TITLE
chore(pre-commit): Upgrade all hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_install_hook_types:
   - commit-msg
   - post-checkout
+  - post-rewrite
   - pre-commit
   - pre-merge-commit
   - pre-push
@@ -15,7 +16,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.5.1
+    rev: 0.5.2
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -36,7 +37,7 @@ repos:
 
   ## Python, TOML, Polyglot, Git
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       ### Automatically fix issues.
       - id: end-of-file-fixer


### PR DESCRIPTION
Install post-rewrite hooks by default now that the `asdf-install`, `poetry-install`, and `pre-commit-install` hooks run post-rewrite.

ScribeMD/pre-commit-hooks 0.5.1 --> 0.5.2
pre-commit/pre-commit-hooks v4.2.0 --> v4.3.0