### PR TITLE
fix(workflow): Grant minimum necessary scopes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,9 @@ jobs:
   test:
     name: Run Pre-commit Hooks
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # for pre-commit-action
+      pull-requests: read # for slack-templates in private repositories
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
pre-commit-action requires the `contents:write` scope, and slack-templates requires the `pull-requests:read` scope. pre-commit action uses the `contents:write` scope to bump the project version via Commitizen. slack-templates uses the `pull-requests:read` scope to determine the pull request associated with a push event to main since the push event itself doesn't contain this information. Granting these specific permissions also has the effect of reducing the scope of all unspecified permissions from read to none for pull requests from Dependabot and forks and from write to none for workflows triggered by anything else (even re-runs of Dependabot pull requests). Since this repository is public, most of its data can be read without additional permissions, but the `pull-requests:read` scope is needed when the calling repository is private.