### PR TITLE
docs(README): Link to tool homepages, not repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pre-commit-action
 
 [![Test Workflow Status](https://github.com/ScribeMD/pre-commit-action/workflows/Test/badge.svg)](https://github.com/ScribeMD/pre-commit-action/actions/workflows/test.yaml)
-[![Git Hooks: pre-commit](https://img.shields.io/badge/pre--commit-Git_Hooks-orange?logo=precommit&logoColor=FAB040)](https://github.com/pre-commit/pre-commit)
+[![Git Hooks: pre-commit](https://img.shields.io/badge/pre--commit-Git_Hooks-orange?logo=precommit&logoColor=FAB040)](https://pre-commit.com/)
 [![Commit Style: Conventional Commits](https://img.shields.io/badge/Conventional_Commits-Commit_Style-yellow?logo=conventionalcommits&logoColor=FE5196)](https://conventionalcommits.org)
-[![Code Style: Prettier](https://img.shields.io/badge/Prettier-Code_Style-FF69B4?logo=prettier&logoColor=F7B93E)](https://github.com/prettier/prettier)
+[![Code Style: Prettier](https://img.shields.io/badge/Prettier-Code_Style-FF69B4?logo=prettier&logoColor=F7B93E)](https://prettier.io/)
 
 GitHub Action Optimized for Running
 [ScribeMD/pre-commit-hooks](https://github.com/ScribeMD/pre-commit-hooks/)


### PR DESCRIPTION
Virtually all tool homepages link to their GitHub repositories anyways, and the homepages generally offer a more enticing user experience.