### PR TITLE
fix(action): Bump commitizen to v2.32.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.31.0 # Keep in sync with action.yaml and pyproject.toml.
+    rev: v2.32.2 # Keep in sync with action.yaml and pyproject.toml.
     hooks:
       - id: commitizen
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/action.yaml
+++ b/action.yaml
@@ -101,4 +101,4 @@ runs:
         git_name: commitizen-github-action[bot]
         git_email: commitizen-github-action[bot]@users.noreply.github.com
         github_token: ${{ github.token }}
-        commitizen_version: 2.31.0 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
+        commitizen_version: 2.32.2 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.


### PR DESCRIPTION
When the Poetry dependency Commitizen was upgraded from v2.31.0 to v2.32.2, the pre-commit hook and version used by the GitHub Action were left at v2.31.0.