### PR TITLE
feat(action): Add `commitizen-branch` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_install_hook_types:
   - commit-msg
   - post-checkout
+  - post-commit
   - post-rewrite
   - pre-commit
   - pre-merge-commit
@@ -89,6 +90,11 @@ repos:
     rev: v2.32.2 # Keep in sync with action.yaml and pyproject.toml.
     hooks:
       - id: commitizen
+      - id: commitizen-branch
+        stages:
+          - post-commit
+          - post-rewrite
+          - push
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/action.yaml
+++ b/action.yaml
@@ -82,12 +82,17 @@ runs:
           docker-${{ steps.os.outputs.image }}-${{
             hashFiles('.pre-commit-config.yaml')
           }}
+    - name: Set default branch for commitizen-branch hook.
+      run: git remote set-head origin --auto
+      shell: bash
+    - name: Skip hooks that would false positive on default branch.
+      if: github.ref == 'refs/heads/main'
+      run: echo "SKIP=commitizen-branch,no-commit-to-branch" >>"$GITHUB_ENV"
+      shell: bash
     - name: Run pre-push hooks.
       uses: pre-commit/action@v3.0.0
       with:
         extra_args: "--all-files --hook-stage push"
-      env:
-        SKIP: no-commit-to-branch
     - name: Uninstall pre-commit hooks. # Don't break subsequent Git commands.
       run: pre-commit uninstall
       shell: bash


### PR DESCRIPTION
The existing `commitizen` hook checks commit messages locally at the time they are written but doesn't run in CI. The recently introduced `commitizen-branch` hook checks commit messages after the fact, so run it `post-commit`, `post-rewrite`, `pre-push`, and in CI. This also prevents empty commit messages from slipping in (e.g., via `git commit --allow-empty-message`) since the `commitizen` hook allows them to avoid false positives on aborted commits. The `commitizen-branch` hook requires `origin/HEAD` to be set, which the official GitHub checkout action doesn't do, so set it manually in the action. Skip the `commitizen-branch` hook on the default branch to prevent false positive regarding empty range.