### PR TITLE
refactor(action): Remove unneeded hook uninstall

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -94,7 +94,6 @@ runs:
         fi
         poetry run pre-commit run \
           --all-files --hook-stage push --show-diff-on-failure --color always
-        poetry run pre-commit uninstall # Don't break subsequent Git commands.
       shell: bash
     - name: Push a commit to main to bump version and update changelog.
       if: >


### PR DESCRIPTION
We previously uninstalled pre-commit hooks prior to running the Commitizen action to prevent them from blocking the auto-generated commit. This was necessary because we used `pre-commit/action`, which installed the pre-commit hooks prior to running them. We have since ported off this deprecated action, so we no longer install the hooks.