### PR TITLE
fix(action): Add back hook uninstall

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -94,6 +94,7 @@ runs:
         fi
         poetry run pre-commit run \
           --all-files --hook-stage push --show-diff-on-failure --color always
+        poetry run pre-commit uninstall # Don't break subsequent Git commands.
       shell: bash
     - name: Push a commit to main to bump version and update changelog.
       if: >


### PR DESCRIPTION
Revert commit 960f99a88ea6bda458ef63a2873c318a9ec4f89c to address failure of Commitizen to commit version bump on merge to main in CI. The `pre-commit-install` hook installs pre-commit hooks, so they do still need to be uninstalled despite the fact that we ported off `pre-commit/action`.