### PR TITLE
refactor(action): Pass `--sync` to `poetry install`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,7 @@ runs:
             hashFiles('**/poetry.lock')
           }}
     - name: Install Poetry dependencies.
-      run: poetry install
+      run: poetry install --sync
       shell: bash
     - name: Get npm cache directory.
       id: npm-cache


### PR DESCRIPTION
The recently released Poetry 1.2.0 introduced support for the `--sync` argument, which removes any dependencies not found in `poetry.lock` from the virtual environment.