### PR TITLE
fix(action): Instruct Poetry to use asdf Python

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,6 +47,9 @@ runs:
           poetry-${{ steps.os.outputs.image }}-${{
             hashFiles('**/poetry.lock')
           }}
+    - name: Configure Poetry to use asdf-managed Python.
+      run: poetry env use "$(asdf which python)"
+      shell: bash
     - name: Install Poetry dependencies.
       run: poetry install --sync
       shell: bash


### PR DESCRIPTION
Upon upgrading from Poetry 1.1.15 to Poetry 1.2.0, we began using the newly introduced experimental `virtualenvs.prefer-active-python` setting via [asdf-poetry](https://github.com/asdf-community/asdf-poetry). So long as the Poetry cache hits, this doesn't cause any problems since the setting only governs the creation of new virtual environments. However, once the Poetry cache first misses, Poetry thereafter creates the virtual environment with the active system version of Python, leading to build failures since our Poetry lock file and pre-commit config both specify the asdf-managed version of Python. Explicitly configure Poetry to use the asdf-managed version of Python prior to creating the virtual environment.