### PR TITLE
ci(Poetry): Exclude pip from virtual environment

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,4 @@
 !preform
 deps
 Laven
+setuptools

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,6 @@
 [virtualenvs]
 in-project = true
+
+[virtualenvs.options]
+no-pip = true
+no-setuptools = true


### PR DESCRIPTION
Leverage the `virtualenvs.options.no-pip` and `virtualenvs.options.no-setuptools` settings newly introduced in Poetry 1.2.0 to save space in the virtual environment and cache space in CI. These settings prevent pip and setuptools from being installed unconditionally, but setuptools is currently still installed by virtue of being a transitive dependency.