### PR TITLE
perf(action): Set up certain asdf tools faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ GitHub Action Optimized for Running
 
 <!--TOC-->
 
-Install [asdf](https://asdf-vm.com/); use asdf to install
-[Node.js](https://nodejs.org), [Python](https://www.python.org), and
-[Poetry](https://python-poetry.org/); use Poetry to install
-[pre-commit](https://pre-commit.com); run pre-commit hooks; and optionally use
+Install [asdf](https://asdf-vm.com/), [Node.js](https://nodejs.org),
+[Python](https://www.python.org), and [Poetry](https://python-poetry.org/); use
+Poetry to install [pre-commit](https://pre-commit.com); run pre-commit hooks;
+and optionally use
 [commitizen-action](https://github.com/commitizen-tools/commitizen-action/) to
 bump the project version. Assume the presence of
 [`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions)

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,41 @@ runs:
       id: os
       run: echo "::set-output name=image::$ImageOS"
       shell: bash
+    - name: Get asdf versions of tools with first-class GitHub Actions support.
+      id: tool-versions
+      run: |
+        file=()
+        while IFS= read -r line; do
+          array=($line)
+          tool="${array[0]}"
+          version="${array[1]}"
+          case $tool in
+            dotnet-core | nodejs | python)
+              echo "::set-output name=$tool::$version"
+              ;;
+
+            *)
+              file+=("$line")
+              ;;
+          esac
+        done <.tool-versions
+
+        # Remove tools to be installed via actions/setup-* from .tool-versions.
+        printf "%s\n" "${file[@]}" >.tool-versions
+      shell: bash
+    - name: Set up .NET SDK at version specified in .tool-versions.
+      if: steps.tool-versions.outputs.dotnet-core != ''
+      uses: actions/setup-dotnet@v2.1.1
+      with:
+        dotnet-version: ${{ steps.tool-versions.outputs.dotnet-core }}
+    - name: Set up Node.js at version specified in .tool-versions.
+      uses: actions/setup-node@v3.5.0
+      with:
+        node-version: ${{ steps.tool-versions.outputs.nodejs }}
+    - name: Set up Python at version specified in .tool-versions.
+      uses: actions/setup-python@v4.2.0
+      with:
+        python-version: ${{ steps.tool-versions.outputs.python }}
     - name: Install asdf.
       uses: asdf-vm/actions/setup@v1.1.0
       with:
@@ -39,6 +74,9 @@ runs:
     - name: Install asdf-managed tools based on .tool-versions.
       if: steps.asdf-cache.outputs.cache-hit != 'true'
       uses: asdf-vm/actions/install@v1.1.0
+    - name: Restore .tool-versions.
+      run: git restore .tool-versions
+      shell: bash
     - name: Get Poetry cache directory.
       id: poetry-cache
       run: |
@@ -56,9 +94,6 @@ runs:
             'poetry.toml',
             '**/poetry.lock'
           ) }}
-    - name: Configure Poetry to use asdf-managed Python.
-      run: poetry env use "$(asdf which python)"
-      shell: bash
     - name: Install Poetry dependencies.
       run: poetry install --sync
       shell: bash
@@ -102,7 +137,9 @@ runs:
         git remote set-head origin --auto # for commitizen-branch hook
 
         if [[ $GITHUB_REF_NAME == 'main' ]]; then
-          export SKIP=commitizen-branch,no-commit-to-branch
+          export SKIP=asdf-install,commitizen-branch,no-commit-to-branch
+        else
+          export SKIP=asdf-install
         fi
         poetry run pre-commit run \
           --all-files --hook-stage push --show-diff-on-failure --color always

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -8,6 +8,7 @@ dictionaryDefinitions:
   - name: custom
     path: .dictionary.txt
 dictionaries:
+  - bash
   - custom
   - fullstack
   - npm


### PR DESCRIPTION
GitHub Actions offers first-class support for setting up .NET SDK, Node.js, and Python at a specified version. These first-class actions leverage recent versions pre-installed on images as well as global caches shared across all GitHub repositories that don't count against our cache space limit.