### PR TITLE
chore(MegaLinter): Upgrade from v5.16.1 to v6.10.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,3 @@
 !preform
-deps
 Laven
 setuptools

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # MegaLinter
-report
+megalinter-reports
 
 # Poetry
 .venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.8.0
+    rev: 0.13.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -25,9 +25,9 @@ repos:
       - id: poetry-lock
       - id: poetry-install
       - id: pre-commit-install
-      - id: megalinter
-        args: &megalinter-args [--flavor, documentation, --release, v5.16.1]
-      - id: megalinter-all
+      - id: megalinter-incremental
+        args: &megalinter-args [--flavor, documentation, --release, v6.10.0]
+      - id: megalinter-full
         args: *megalinter-args
 
   ## Markdown


### PR DESCRIPTION
Replace MegaLinter v5 hooks with v6 hooks.
Remove "deps" from custom dictionary; it was added to the Python dictionary upstream.