### PR TITLE
fix(action): Instruct Poetry to honor setup-python

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -94,6 +94,9 @@ runs:
             'poetry.toml',
             '**/poetry.lock'
           ) }}
+    - name: Configure Poetry to use Python version specified in .tool-versions.
+      run: poetry env use "${{ steps.tool-versions.outputs.python }}"
+      shell: bash
     - name: Install Poetry dependencies.
       run: poetry install --sync
       shell: bash


### PR DESCRIPTION
Explicitly configure Poetry to use the version of Python configured via [actions/setup-python](https://github.com/actions/setup-python). Otherwise, it uses a version preinstalled on the runner image.