### PR TITLE
perf(action): Make Docker cache key more precise

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -118,13 +118,32 @@ runs:
           ) }}
     - name: Use Docker in rootless mode.
       uses: ScribeMD/rootless-docker@0.2.2
+    - name: Determine name of MegaLinter Docker image from pre-commit config.
+      id: megalinter
+      run: |
+        from os import environ
+        from re import compile
+
+        _MEGALINTER_ARGS_PATTERN = compile(
+            "args:\\s*&megalinter-args\\s*\\[--flavor,\\s*(?P<flavor>\\w+),"
+            "\\s*--release,\\s*(?P<release>v(\\d+\\.){2}\\d+)"
+        )
+        with open(".pre-commit-config.yaml", encoding="utf-8") as input_stream:
+            for line in input_stream:
+                if match := _MEGALINTER_ARGS_PATTERN.search(line):
+                    break
+
+        flavor = match.group("flavor")
+        release = match.group("release")
+        docker_image = f"megalinter-{flavor}:{release}"
+        output_file = environ["GITHUB_OUTPUT"]
+        with open(output_file, "a", encoding="utf-8") as output_stream:
+            output_stream.write(f"DOCKER_IMAGE={docker_image}\n")
+      shell: python
     - name: Cache Docker images.
       uses: ScribeMD/docker-cache@0.2.6
       with:
-        key: >
-          docker-${{ steps.os.outputs.IMAGE }}-${{
-            hashFiles('.pre-commit-config.yaml')
-          }}
+        key: ${{ steps.megalinter.outputs.DOCKER_IMAGE }}
     - name: Cache pre-commit hooks.
       uses: actions/cache@v3.0.11
       with:


### PR DESCRIPTION
Only invalidate the Docker cache when the MegaLinter flavor or release change. Previously the cache was invalidated any time `.pre-commit-config.yaml` was modified. This made the cache less efficient since the pre-commit config is frequently modified.