### PR TITLE
docs(README): Update MegaLinter documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ bump the project version. Assume the presence of
 specifying versions for Node.js, Python, and Poetry as well as
 [`poetry.lock`](https://python-poetry.org/docs/basic-usage/#installing-with-poetrylock).
 Cache Poetry dependencies. Cache Node.js packages specified in
-[`.mega-linter.yaml`](https://oxsecurity.github.io/megalinter/), `.pre-commit-config.yaml`,
-and/or `.pre-commit-hooks.yaml`. Since
+[`.mega-linter.yaml`](https://megalinter.io/), `.pre-commit-config.yaml`, and/or
+`.pre-commit-hooks.yaml`. Since
 [pre-commit supports Docker](https://pre-commit.com/#docker_image), cache
 [Docker](https://www.docker.com/) images. Cache pre-commit hook environments.
 Set `origin/HEAD` to the default branch to support the


### PR DESCRIPTION
The MegaLinter documentation has been moved from
https://oxsecurity.github.io/megalinter/ to https://megalinter.io/.