### PR TITLE
perf(action): Partially restore Poetry/pre-commit

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -90,10 +90,13 @@ runs:
           ${{ steps.poetry-cache.outputs.PATH }}
           .venv
         key: >
-          poetry-${{ steps.os.outputs.IMAGE }}-${{ hashFiles(
-            'poetry.toml',
-            '**/poetry.lock'
-          ) }}
+          poetry-${{ steps.os.outputs.IMAGE }}-python${{
+            steps.tool-versions.outputs.python
+          }}-${{
+            hashFiles('poetry.toml', '**/poetry.lock')
+          }}
+        restore-keys: |
+          poetry-${{ steps.os.outputs.IMAGE }}-python${{ steps.tool-versions.outputs.python }}-
     - name: Configure Poetry to use Python version specified in .tool-versions.
       run: poetry env use "${{ steps.tool-versions.outputs.python }}"
       shell: bash
@@ -154,6 +157,7 @@ runs:
             '**/poetry.lock',
             '.pre-commit-config.yaml'
           ) }}
+        restore-keys: pre-commit-${{ steps.os.outputs.IMAGE }}-
     - name: Run pre-push hooks.
       run: |
         git remote set-head origin --auto # for commitizen-branch hook
@@ -163,6 +167,7 @@ runs:
         else
           export SKIP=asdf-install
         fi
+        poetry run pre-commit gc # Avoid partial cache restoration snowballing.
         poetry run pre-commit run \
           --all-files --hook-stage push --show-diff-on-failure --color always
         poetry run pre-commit uninstall # Don't break subsequent Git commands.


### PR DESCRIPTION
Implement partial cache restoration for Poetry and pre-commit, allowing cache hits when Poetry dependencies or pre-commit hooks are upgraded. These are the two tools that are currently capable of avoiding partial cache restoration snowballing, where the cache bloats over time because previously used dependencies aren't actively removed. Poetry already uses `poetry install --sync`, which removes any no longer needed dependencies from the cache. Run pre-commit's garbage collector to achieve the same effect for its cache. Include the Python version explicitly in the Poetry cache key since the cache isn't valid across Python versions anyways, and hence partial cache restoration would only decrease performance when upgrading Python. The Python version is in `poetry.lock`, but in order to restore the cache only when the Python version matches even if some Poetry dependencies were upgraded, the Python version must be included explicitly in the cache key. This change
to the cache key format invalidates all Poetry caches.