### PR TITLE
chore(Commitizen): Use Poetry version provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool]
   [tool.commitizen]
-  version = "0.9.79"
-  version_files = [
-    "pyproject.toml:version",
-    "README.md:pre-commit-action@"
-  ]
+  version_provider = "poetry"
+  version_files = ["README.md:pre-commit-action@"]
   major_version_zero = true
 
   [tool.poetry]


### PR DESCRIPTION
Commitizen recently introduced version providers in v3.0.0 so that the project version number no longer needs to be duplicated between the Commitizen and Poetry configs.