### PR TITLE
chore(Renovate): Migrate to `matchFileNames`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["github>ScribeMD/.github#0.14.8"],
   "packageRules": [
     {
-      "matchFiles": [".github/workflows/test.yaml"],
+      "matchFileNames": [".github/workflows/test.yaml"],
       "semanticCommitType": "fix"
     }
   ]


### PR DESCRIPTION
`matchFiles` was replaced with `matchFileNames` in Renovate v36.0.0.